### PR TITLE
Zaabee.ZeroFormatter adds support for .NET Core 3.1

### DIFF
--- a/src/Zaabee.ZeroFormatter/Zaabee.ZeroFormatter.csproj
+++ b/src/Zaabee.ZeroFormatter/Zaabee.ZeroFormatter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+	    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageVersion>2020.1.0</PackageVersion>
         <Version>2020.1.0</Version>
@@ -14,9 +14,10 @@
         <LangVersion>Latest</LangVersion>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Zaabee.Extensions" Version="2020.1.0" />
-        <PackageReference Include="ZeroFormatter" Version="1.6.4" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Zaabee.Extensions" Version="2020.1.0" />
+		<PackageReference Include="ZeroFormatter" Version="1.6.4" Condition="'$(TargetFramework)'=='netstandard2.0'"/>
+		<PackageReference Include="Alexinea.ZeroFormatter" Version="1.6.4" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+	</ItemGroup>
 
 </Project>

--- a/tests/ZaabeeZeroFormatterTestProject/ZaabeeZeroFormatterTestProject.csproj
+++ b/tests/ZaabeeZeroFormatterTestProject/ZaabeeZeroFormatterTestProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
Use `Alexinea.ZeroFormatter` on netcoreapp3.1 TargetFramework, the package is based on the [official project](https://github.com/neuecc/ZeroFormatter) and the downstream repo of [MyIntelligenceAgency](https://github.com/MyIntelligenceAgency/ZeroFormatter).  

The unit test has passed.

https://github.com/neuecc/ZeroFormatter/issues/112